### PR TITLE
[WIP/RFC] Make Parametric class constructor more like Julia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cover
 # Other
 .DS_Store
 *.swp
+.envrc
 
 # Cython build files
 *.html

--- a/README.md
+++ b/README.md
@@ -827,50 +827,65 @@ from plum import dispatch, parametric
 
 @parametric
 class A:
-    pass
+    def __init__(self, x, *, y = 3):
+        self.x = x
+        self.y = y
     
     
 @dispatch
 def f(x: A):
-    return "fallback"
+    return "fallback: x={}".format(x.x)
     
     
 @dispatch
-def f(x: A[1]):
-    return "1"
+def f(x: A[int]):
+    return "int x={}".format(x.x)
     
     
 @dispatch
-def f(x: A[2]):
-    return "2"
+def f(x: A[float]):
+    return "float x={}".format(x.x)
 ```
 
 ```python
 >>> A
 __main__.A
 
->>> A[1]
-__main__.A[1]
+>>> A[int]
+__main__.A[builtins.int]
 
->>> issubclass(A[1], A)
+>>> issubclass(A[int], A)
 True
 
->>> A[1]()
-<__main__.A[1] at 0x10c2bab70>
+>>> type(A(1)) == A[int]
+True
 
->>> f(A[1]())
-'1'
+>>> A[int](1)
+<__main__.A[builtins.int] at 0x10c2bab70>
 
->>> f(A[2]())
-'2'
+>>> f(A[int](1))
+'int x=1'
 
->>> f(A[3]())
-'fallback'
+>>> f(A(1))
+'int x=1'
+
+>>> f(A(1.0))
+'float x=1.0'
+
+>>> f(A(1 + 1j))
+'fallback: x=1+1j'
 ```
 
-**Note:** A current limitation is that an instance of `A` can only be instantiated if a 
-type parameter is provided.
-For example, `A[1]()` works, but `A()` gives unexpected results.
+**Note:** Calling `A[pars]` on parametrized type `A` instantiates the concrete
+type with parameters `pars`.
+If `A(args)` is called directly, the concrete type is first instantiated by
+taking the type of all positional arguments, and then an instance of the type 
+is created.
+
+This only works for types whose `__init__` method accepts positional arguments.
+If parametric type `A` does not take positional arguments, then the only way to 
+instantiate it is to first create the concrete type `A[pars]` and then construct
+it `A[pars]()`.
 
 ### Hooking Into Type Inference
 

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -39,9 +39,12 @@ class ParametricTypeMeta(TypeMeta):
     `Type[type(Arg1), type(Arg2)](Arg1, Arg2, **kw_args)`.
     """
 
-    def __getitem__(self, *ps):
+    def __getitem__(self, p):
         if not self.is_concrete:
-            return self.__new__(self, *ps)
+            if isinstance(p, tuple):
+                return self.__new__(self, *p)
+            else:
+                return self.__new__(self, p)
         else:
             raise TypeError("Cannot specify type parameters. This type is concrete.")
 

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -31,17 +31,12 @@ log = logging.getLogger(__name__)
 _dispatch = Dispatcher()
 
 class ParametricTypeMeta(TypeMeta):
-    """Types can also be instantiated with indexing."""
+    """Parametric Types must be instantiated with indexing."""
 
-    def __getitem__(self, p):
+    def __getitem__(self, *p):
         # Type[Par1, Par2] creates a new parametric type
 
-        cls = self
-        if isinstance(p, tuple):
-            return cls.__new__(cls, *p)
-        else:
-            # cls = p
-            return cls.__new__(cls, p)
+        return self.__new__(self, *p)
 
     def __call__(cls, *args, **kwargs):
         # Type(arg1, arg2, kwargs) will first construct the

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -210,7 +210,7 @@ class List(ComparableType):
         return f"List[{self._el_type}]"
 
     def get_types(self):
-        return (_ParametricList(self._el_type),)
+        return (_ParametricList[self._el_type],)
 
     @property
     def parametric(self):
@@ -246,7 +246,7 @@ class Tuple(ComparableType):
         return f'Tuple[{", ".join(map(str, self._el_types))}]'
 
     def get_types(self):
-        return (_ParametricTuple(*self._el_types),)
+        return (_ParametricTuple[self._el_types],)
 
     @property
     def parametric(self):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -32,7 +32,7 @@ _dispatch = Dispatcher()
 
 
 class ParametricTypeMeta(TypeMeta):
-    """Parametric Types can be instantiated with indexing.
+    """Parametric types can be instantiated with indexing.
 
     A concrete parametric type can be instantiated by calling `Type[Par1, Par2]`.
     If `Type(Arg1, Arg2, **kw_args)` is called, this returns
@@ -46,19 +46,19 @@ class ParametricTypeMeta(TypeMeta):
             raise TypeError("Cannot specify type parameters. This type is concrete.")
 
     def __call__(cls, *args, **kw_args):
-        # Type(arg1, arg2, kw_args) will first construct the
-        # parametric subtype T = Type[type(arg1), type(arg2)]
-        # and then call the equivalent of T(arg1, arg2, **kw_args)
+        # `Type(arg1, arg2, **kw_args)` will first construct the
+        # parametric subtype `T = Type[type(arg1), type(arg2)]`
+        # and then call the equivalent of `T(arg1, arg2, **kw_args)`.
 
         if not cls.is_concrete:
-            argsT = tuple(type(arg) for arg in args)
-            if len(argsT) == 1:
-                argsT = argsT[0]
-            T = cls[argsT]
+            type_parameter = tuple(type(arg) for arg in args)
+            if len(type_parameter) == 1:
+                type_parameter = type_parameter[0]
+            T = cls[type_parameter]
         else:
             T = cls
 
-        # calls __new__ and __init__
+        # Calls `__new__` and `__init__`.
         return type.__call__(T, *args, **kw_args)
 
     @property

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -57,6 +57,7 @@ class ParametricTypeMeta(TypeMeta):
 
     @property
     def is_concrete(cls):
+        """"bool: Check whether the parametric type is instantiated or not."""
         return hasattr(cls, "_is_parametric")
 
 

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -30,11 +30,11 @@ log = logging.getLogger(__name__)
 
 _dispatch = Dispatcher()
 
+
 class ParametricTypeMeta(TypeMeta):
     """Parametric Types can be instantiated with indexing.
-    
-    A concrete parametric type can be instantiated by calling
-    `Type[Par1, Par2]`. 
+
+    A concrete parametric type can be instantiated by calling `Type[Par1, Par2]`.
     If `Type(Arg1, Arg2, **kw_args)` is called, this returns
     `Type[type(Arg1), type(Arg2)](Arg1, Arg2, **kw_args)`.
     """
@@ -43,8 +43,7 @@ class ParametricTypeMeta(TypeMeta):
         if not self.is_concrete:
             return self.__new__(self, *ps)
         else:
-            raise TypeError("Cannot specify type parameters. "
-                            "This type is concrete.")
+            raise TypeError("Cannot specify type parameters. This type is concrete.")
 
     def __call__(cls, *args, **kw_args):
         # Type(arg1, arg2, kw_args) will first construct the
@@ -64,7 +63,7 @@ class ParametricTypeMeta(TypeMeta):
 
     @property
     def is_concrete(cls):
-        """"bool: Check whether the parametric type is instantiated or not."""
+        """bool: Check whether the parametric type is instantiated or not."""
         return hasattr(cls, "_is_parametric")
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = plum-dispatch
-version = 1.1.1
+version = 1.2.0
 author = Wessel Bruinsma
 author_email = wessel.p.bruinsma@gmail.com
 description = Multiple dispatch in Python

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -99,6 +99,7 @@ def test_constructor():
     assert type_parameter(a1) == float
     assert type_parameter(a2) == float
     assert type(a1) == type(a2)
+    assert type(a1).__name__ == type(a2).__name__ == f"A[{float}]"
 
     @parametric
     class B:

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -75,7 +75,7 @@ def test_parametric():
     assert tuple_elements_are_identical(type_parameter(A[a1, a2]()), (a1, a2))
     assert tuple_elements_are_identical(type_parameter(A[1, a2]()), (1, a2))
 
-    # test raise error if specify parameters twice
+    # Test that an error is raised if type parameters are specified twice.
     T = A[1]
     with pytest.raises(TypeError):
         T[1]

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -76,16 +76,42 @@ def test_parametric():
     assert tuple_elements_are_identical(type_parameter(A[1, a2]()), (1, a2))
 
 
-def test_argument():
+def test_constructor():
     @parametric
     class A:
-        def __init__(self, x):
+        def __init__(self, x, *, y = 3):
             self.x = x
+            self.y = y
 
-    a = A[1](5.0)
+    a1 = A[float](5.0)
+    a2 = A(5.0)
 
-    assert a.x == 5.0
+    assert a1.x == 5.0
+    assert a2.x == 5.0
+    assert a1.y == 3
+    assert a2.y == 3
 
+    assert type_parameter(a1) == float
+    assert type_parameter(a2) == float
+    assert type(a1) == type(a2)
+
+    @parametric
+    class B:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+    b1 = B[float, int](5.0, 3)
+    b2 = B(5.0, 3)
+
+    assert b1.x == 5.0
+    assert b2.x == 5.0
+    assert b1.y == 3
+    assert b2.y == 3
+
+    assert type_parameter(b1) == (float, int)
+    assert type_parameter(b2) == (float, int)
+    assert type(b1) == type(b2)
 
 def test_kind():
     assert Kind[1] == Kind[1]

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -75,6 +75,11 @@ def test_parametric():
     assert tuple_elements_are_identical(type_parameter(A[a1, a2]()), (a1, a2))
     assert tuple_elements_are_identical(type_parameter(A[1, a2]()), (1, a2))
 
+    # test raise error if specify parameters twice
+    T = A[1]
+    with pytest.raises(TypeError):
+        T[1]
+
 
 def test_constructor():
     @parametric

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -79,7 +79,7 @@ def test_parametric():
 def test_constructor():
     @parametric
     class A:
-        def __init__(self, x, *, y = 3):
+        def __init__(self, x, *, y=3):
             self.x = x
             self.y = y
 
@@ -112,6 +112,7 @@ def test_constructor():
     assert type_parameter(b1) == (float, int)
     assert type_parameter(b2) == (float, int)
     assert type(b1) == type(b2)
+
 
 def test_kind():
     assert Kind[1] == Kind[1]

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -118,6 +118,7 @@ def test_constructor():
     assert type_parameter(b1) == (float, int)
     assert type_parameter(b2) == (float, int)
     assert type(b1) == type(b2)
+    assert type(b1).__name__ == type(b2).__name__ == f"B[{float},{int}]"
 
 
 def test_kind():


### PR DESCRIPTION
I am putting this here to get some feedback...
This is a tentative implementation of what I described in #9

the objective was that given the parametric class

```python
@plum.parametric
class Test:
    def __init__(self, a, *, b=3):
        self.a = a
        self.b = b
```

I would like to replace 
```python
T = Test[list]
obj = T([1,2,3], b=4)
```
with
```python
obj = Test([1,2,3], b=4)
type(obj)  # __main__.Test[<class 'list'>]
```

The syntax `Test[par]` still works.

--

I achieve this by introducing a new MetaClass, that I call `ParametricTypeMeta`, which should be only used for parametric objects, which overrides `__getitem__` to call`__new__` instead of `__call__`, and I override `__call__` to only instantiate the object if it's a concrete subtype.

What would you think about this?