### PR TITLE
Accept *None* as valid type annotation

### DIFF
--- a/plum/type.py
+++ b/plum/type.py
@@ -362,6 +362,9 @@ def ptype(obj):
     if isinstance(obj, type):
         return Type(obj)
 
+    if obj is None:
+        return Type(type(None))
+
     raise RuntimeError(f'Could not convert "{obj}" to a type.')
 
 

--- a/tests/dispatcher/test_cases.py
+++ b/tests/dispatcher/test_cases.py
@@ -341,3 +341,13 @@ def test_property():
     a.name = "another name"
     with pytest.raises(NotFoundLookupError):
         a.name = 1
+
+
+def test_none():
+    dispatch = Dispatcher()
+
+    @dispatch
+    def foo(x: None) -> None:
+        return x
+
+    assert foo(None) is None

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -125,6 +125,9 @@ def test_astype():
     assert ptype(t) is t
     assert ptype(int) == t
 
+    # Check *None* as valid type annotation
+    assert ptype(None) == Type(type(None))
+
     # Check conversion of strings.
     t = ptype("A")
     deliver_forward_reference(A)


### PR DESCRIPTION
Accept `None` as valid type annotations, so that the following code snippet works:
```py
from plum import dispatch


def foo(x: None) -> None:
  return x


assert foo(None) is None
```

The solution simply checks if functions contain `None` as type annotation and, if so, automatically converts them to `builtins.NoneType`.

Closes #13 