### PR TITLE
[WIP] cythonize plum.parametric

### DIFF
--- a/plum/type.py
+++ b/plum/type.py
@@ -356,7 +356,12 @@ def ptype(obj):
 
     # Strings are forward references.
     if isinstance(obj, str):
-        return get_forward_reference(obj)
+        if obj == "list":
+            return ptype(list)
+        elif obj == "tuple":
+            return ptype(tuple)
+        else:
+            return get_forward_reference(obj)
 
     # If `obj` is a `type`, wrap it in a `Type`.
     if isinstance(obj, type):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     packages=find_packages(exclude=["docs"]),
     python_requires=">=3.6",
     install_requires=requirements,
-    ext_modules=[Extension("plum.function", ["plum/function.py"]), 
-                 Extension("plum.parametric", ["plum/parametric.py"])],
+    ext_modules=[
+        Extension("plum.function", ["plum/function.py"]),
+        Extension("plum.parametric", ["plum/parametric.py"]),
+    ],
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     packages=find_packages(exclude=["docs"]),
     python_requires=">=3.6",
     install_requires=requirements,
-    ext_modules=[Extension("plum.function", ["plum/function.py"])],
+    ext_modules=[Extension("plum.function", ["plum/function.py"]), 
+                 Extension("plum.parametric", ["plum/parametric.py"])],
     include_package_data=True,
 )

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -132,7 +132,10 @@ def test_metadata_and_printing():
     assert g.invoke().__name__ == "g"
     assert g.invoke().__doc__ == "docstring of g"
     assert g.invoke().__module__ == "tests.dispatcher.test_dispatcher"
-    assert repr(g.invoke())[:-n].replace("cyfunction", "function") == repr(A._dispatch._classes[A]["g"]._f)[:-n]
+    assert (
+        repr(g.invoke())[:-n].replace("cyfunction", "function")
+        == repr(A._dispatch._classes[A]["g"]._f)[:-n]
+    )
 
 
 def test_multi():

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -116,7 +116,10 @@ def test_metadata_and_printing():
     assert f.invoke().__doc__ == "docstring of f"
     assert f.invoke().__module__ == "tests.dispatcher.test_dispatcher"
     n = len(hex(id(f))) + 1  # Do not check memory address and extra ">".
-    assert repr(f.invoke())[:-n] == repr(f._f)[:-n]
+    # also replace cyfunction with function
+    _str1 = repr(f.invoke())[:-n].replace("cyfunction", "function")
+    _str2 = repr(f._f)[:-n]
+    assert _str1 == _str2
 
     a = A()
     g = a.g
@@ -129,7 +132,7 @@ def test_metadata_and_printing():
     assert g.invoke().__name__ == "g"
     assert g.invoke().__doc__ == "docstring of g"
     assert g.invoke().__module__ == "tests.dispatcher.test_dispatcher"
-    assert repr(g.invoke())[:-n] == repr(A._dispatch._classes[A]["g"]._f)[:-n]
+    assert repr(g.invoke())[:-n].replace("cyfunction", "function") == repr(A._dispatch._classes[A]["g"]._f)[:-n]
 
 
 def test_multi():


### PR DESCRIPTION
I experimented with cythonizing the plum.parametric module to speed it up a bit (for my own personal peace of mind).

Other than slightly modifying the test because now `typeof` is a function instead of a `function`, there is a change needed:

In Cython, type hints are all strings. So the `type_of` dispatches of `typeof(obj: list)` and `typeof(obj: tuple)` in `plum.parametric` will have a string and type instead of a real class, thus in type.py they will be forward references/promises which are never _fullfilled_.

Apparently plum breaks down when those two promises are not fulfilled.
A fix was to hardcode those two cases in ptype:
```python
def ptype(obj):

    if hasattr(obj, "__module__") and obj.__module__ == "typing":
        ...
    if isinstance(obj, str):
        if obj == "list":
            return ptype(list)
        elif obj == "tuple":
            return ptype(tuple)
        else:
            return get_forward_reference(obj)
```

there's probably a better way to address this, but I can't see it now.
The PromisedType mechanism is a bit confusing...