### PR TITLE
Add Val Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,10 +935,30 @@ If `A(args)` is called directly, the concrete type is first instantiated by
 taking the type of all positional arguments, and then an instance of the type 
 is created.
 
-This only works for types whose `__init__` method accepts positional arguments.
-If parametric type `A` does not take positional arguments, then the only way to 
-instantiate it is to first create the concrete type `A[pars]` and then construct
-it `A[pars]()`.
+This behaviour can be customized by overriding the classmethod `__infer_type_parameters`
+of the parametric class. This method must return the type parameter or a tuple of type
+parameters.
+
+````python
+from plum import parametric
+
+@parametric
+class NTuple:
+    @classmethod
+    def __infer_type_parameter__(self, *vals, **kw_args):
+        # Mimicks the type parameters of an `NTuple`.
+        T = type(vals[0])
+        N = len(vals)
+        return (N, T)
+
+    def __init__(self, *vals):
+        T = type(self)._type_parameter[1]
+        assert all(isinstance(val, T) for val in vals)
+        self.vals = vals
+
+>>>>>> type(NTuple(1,2,3))
+<class '__main__.NTuple[3,<class 'int'>]'>
+```
 
 ### Hooking Into Type Inference
 

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -330,8 +330,7 @@ promised_type_of2.deliver(type_of)
 
 @parametric
 class Val:
-    """
-    A parametric type used to move information from the value-domain to the type-domain.
+    """A parametric type used to move information from the value domain to the type domain.
     """
 
     @classmethod

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -132,7 +132,7 @@ def parametric(Class):
 
     ```python
     @classmethod
-    __infer_type_parameter__(cls, *vals, **kw_args) -> Tuple:
+    __infer_type_parameter__(cls, *args, **kw_args) -> Tuple:
         return tuple(type(arg) for arg in args)
     ```
     """

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -79,6 +79,8 @@ class ParametricTypeMeta(TypeMeta):
         Returns:
             type or tuple[type]: A type or tuple of types.
         """
+
+        # TODO: Use `type_of` instead of `type`
         type_parameter = tuple(type(arg) for arg in args)
         if len(type_parameter) == 1:
             type_parameter = type_parameter[0]
@@ -330,8 +332,7 @@ promised_type_of2.deliver(type_of)
 
 @parametric
 class Val:
-    """A parametric type used to move information from the value domain to the type domain.
-    """
+    """A parametric type used to move information from the value domain to the type domain."""
 
     @classmethod
     def __infer_type_parameter__(cls, *arg, **kw_args):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -73,7 +73,8 @@ class ParametricTypeMeta(TypeMeta):
         metaclass.
 
         Args:
-            *args: the argument-values passed to the __init__ method.
+            *args: Positional arguments passed to the `__init__` method.
+            *kw_args: Keyword arguments passed to the `__init__` method.
 
         Returns:
             A type or tuple of types.

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -79,7 +79,7 @@ class ParametricTypeMeta(TypeMeta):
         Returns:
             type or tuple[type]: A type or tuple of types.
         """
-        type_parameter = tuple(type_of(arg) for arg in args)
+        type_parameter = tuple(type(arg) for arg in args)
         if len(type_parameter) == 1:
             type_parameter = type_parameter[0]
         return type_parameter
@@ -330,7 +330,8 @@ promised_type_of2.deliver(type_of)
 
 @parametric
 class Val:
-    """A parametric type used to move information from the value domain to the type domain."""
+    """A parametric type used to move information from the value domain to the type domain.
+    """
 
     @classmethod
     def __infer_type_parameter__(cls, *arg, **kw_args):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -79,7 +79,7 @@ class ParametricTypeMeta(TypeMeta):
         Returns:
             type or tuple[type]: A type or tuple of types.
         """
-        type_parameter = tuple(type(arg) for arg in args)
+        type_parameter = tuple(type_of(arg) for arg in args)
         if len(type_parameter) == 1:
             type_parameter = type_parameter[0]
         return type_parameter
@@ -330,8 +330,7 @@ promised_type_of2.deliver(type_of)
 
 @parametric
 class Val:
-    """A parametric type used to move information from the value domain to the type domain.
-    """
+    """A parametric type used to move information from the value domain to the type domain."""
 
     @classmethod
     def __infer_type_parameter__(cls, *arg, **kw_args):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -355,7 +355,7 @@ class Val:
         if type(self).is_concrete:
             return
         else:
-            raise ValueError("The value must be specified.")  # pragma: no cover
+            raise ValueError("The value must be specified.")
 
     def __repr__(self):
         return f"{repr(type(self))}()"

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -341,7 +341,7 @@ class Val:
         if len(arg) == 0:
             raise ValueError("The value must be specified.")
         elif len(arg) > 1:
-            raise ValueError("Too many values. Val accepts only one argument.")
+            raise ValueError("Too many values. `Val` accepts only one argument.")
         return arg[0]
 
     def __init__(self, arg=None):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -358,7 +358,7 @@ class Val:
             raise ValueError("The value must be specified.")  # pragma: no cover
 
     def __repr__(self):
-        return "{}()".format(repr(type(self)))
+        return f"{repr(type(self))}()"
 
     def __eq__(self, other):
         return type(self) == type(other)

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -122,17 +122,17 @@ class CovariantMeta(ParametricTypeMeta):
 
 def parametric(Class):
     """A decorator for parametric classes.
-    
+
     When the constructor of this parametric type is called before the type parameter
-    has been specified, the type parameters are inferred from the arguments of the 
+    has been specified, the type parameters are inferred from the arguments of the
     constructor by calling the following function.
 
     The default implementation is shown here, but it is possible to override it.
 
-    ```python 
+    ```python
     @classmethod
     __infer_type_parameter__(cls, *vals, **kw_args) -> Tuple:
-        return tuple(type(arg) for arg in args)    
+        return tuple(type(arg) for arg in args)
     ```
     """
     subclasses = {}

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -55,10 +55,6 @@ class ParametricTypeMeta(TypeMeta):
         # parametric subtype `T = Type[type(arg1), type(arg2)]`
         # and then call the equivalent of `T(arg1, arg2, **kw_args)`.
 
-        print("call: cls:", cls)
-        print("call, arg:", args)
-        print("call, kw_args:", kw_args)
-
         if not cls.is_concrete:
             type_parameter = cls._init_args_types(*args)
             T = cls[type_parameter]
@@ -369,7 +365,10 @@ class Val:
         if type(self).is_concrete:
             return
         else:
-            raise ValueError("The value must be specified.")
+            raise ValueError("The value must be specified.")  # pragma: no cover
 
     def __repr__(self):
         return "{}()".format(repr(type(self)))
+
+    def __eq__(self, other):
+        return type(self) == type(other)

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -77,7 +77,7 @@ class ParametricTypeMeta(TypeMeta):
             *kw_args: Keyword arguments passed to the `__init__` method.
 
         Returns:
-            A type or tuple of types.
+            type or tuple[type]: A type or tuple of types.
         """
         type_parameter = tuple(type(arg) for arg in args)
         if len(type_parameter) == 1:

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -334,7 +334,7 @@ class Val:
     """
 
     @classmethod
-    def __infer_type_parameter__(cls, *arg, **kwargs):
+    def __infer_type_parameter__(cls, *arg, **kw_args):
         """Function called when the constructor of `Val` is called to determine the type
         parameters.
         """

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -123,10 +123,8 @@ def test_constructor():
 
 
 def test_override_type_parameters():
-
     @parametric
     class NTuple:
-
         @classmethod
         def __infer_type_parameter__(self, *vals, **kwargs):
             # mimicks the type parameters of an NTuple

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -126,8 +126,8 @@ def test_override_type_parameters():
     @parametric
     class NTuple:
         @classmethod
-        def __infer_type_parameter__(self, *vals, **kwargs):
-            # mimicks the type parameters of an NTuple
+        def __infer_type_parameter__(self, *vals, **kw_args):
+            # Mimicks the type parameters of an `NTuple`.
             T = type(vals[0])
             N = len(vals)
             return (N, T)

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -323,7 +323,7 @@ def test_type_of_extension():
         f(np.random.randn(10, 10, 10))
 
 
-def test_Val():
+def test_val():
     T = Val[3]
     v = Val(3)
 

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -123,14 +123,17 @@ def test_constructor():
 
 
 def test_override_type_parameters():
-    # mimicks the type parameters of an NTuple
-    def _init_type_params(cls, *args):
-        T = type(args[0])
-        N = len(args)
-        return (N, T)
 
-    @parametric(init_args_types=_init_type_params)
+    @parametric
     class NTuple:
+
+        @classmethod
+        def __infer_type_parameter__(self, *vals, **kwargs):
+            # mimicks the type parameters of an NTuple
+            T = type(vals[0])
+            N = len(vals)
+            return (N, T)
+
         def __init__(self, *vals):
             T = type(self)._type_parameter[1]
             assert all(isinstance(val, T) for val in vals)


### PR DESCRIPTION
This PR adds a `Val` type (similar to julia's Val type).
To do so, I add a hook to override the deduction of the type-parameters when calling `parametrictype(args...)`.

The hook is simply a function, provided to the `@parametric` decorator, that takes the arguments as input and must return the type parameters as output.
The default mechanism is now switched to a default implementation of this function.

I need to document what is added in this PR, but i'd like to know if you'd accept this first.

--

The motivation for this is that i have some bool values in netket that i'd like to use to dispatch on the right implementation.
As those values are jax-jit time constants, it makes sense to use them for dispatch to the right implementation...

