### PR TITLE
[WIP] Support default arguments as additional signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,17 +304,17 @@ For more advanced use cases of forward references, you can use `plum.type.Promis
 
 Default arguments can be used. The type annotation must match the default value otherwise 
 an error is thrown. 
-Different default values can be used in different dispatch rules.
+As the example below illustrates, different default values can be used for different methods:
 
 ```python
 from plum import dispatch
 
 @dispatch
-def f(x:int, y:int=3):
+def f(x: int, y: int = 3):
     return f"Value for 2nd y: {y}"
 
 @dispatch
-def f(x:float, y:float=3.0):
+def f(x: float, y: float = 3.0):
     return f"Value for 2nd y: {y}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -302,9 +302,34 @@ For more advanced use cases of forward references, you can use `plum.type.Promis
 
 ## Keyword Arguments and Default Values
 
-Keyword arguments can be used, but are *not* dispatched on.
-As a convention, arguments with default values should always be called as keyword 
-arguments.
+Default arguments can be used. The type annotation must match the default value otherwise 
+an error is thrown. 
+Different default values can be used in different dispatch rules.
+
+```python
+from plum import dispatch
+
+@dispatch
+def f(x:int, y:int=3):
+    return f"Value for 2nd y: {y}"
+
+@dispatch
+def f(x:float, y:float=3.0):
+    return f"Value for 2nd y: {y}"
+```
+
+```python
+>>> f(1)
+'Value for 2nd y: 3'
+
+>>> f(1.0)
+'Value for 2nd y: 3.0'
+
+>>> f(1.0, 4.0)
+'Value for 2nd y: 4.0'
+```
+
+Keyword-only arguments, separated by an asterisk from the other arguments, can also be used, but are *not* dispatched on.
 
 Example:
 
@@ -312,7 +337,7 @@ Example:
 from plum import dispatch
 
 @dispatch
-def f(x, option="a"):
+def f(x, *, option="a"):
     return f"Value for option: {option}"
 ```
 
@@ -327,33 +352,6 @@ def f(x, option="a"):
 NotFoundLookupError: For function "f", signature Signature(builtins.int, builtins.str) could not be resolved.
 ```
 
-If you want to use a default value for a positional argument, use the following pattern
-instead:
-
-
-```python
-from plum import dispatch
-
-@dispatch
-def f(x, option):
-    return f"Value for option: {option}"
-
-
-@dispatch
-def f(x):
-    return f(x, "a")  # Use default value for `option`.
-```
-
-```python
->>> f(1)              # This is fine.
-'Value for option: a'
-
->>> f(1, "b")         # And this will work!
-'Value for option: b'
-
->>> f(1, option="b")  # But this won't.
-TypeError: f() got an unexpected keyword argument 'option'
-```
 
 ## Comparison with `multipledispatch`
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -105,18 +105,21 @@ def extract_default_args(signature, f):
     signatures = [signature]
 
     arg_names = list(sig.parameters.keys())
+    # We start at the end and, once we reach non-keyword-only arguments, delete the
+    # argument with defaults values one by one. This generates a sequence of signatures,
+    # which we return.
     arg_names.reverse()
     n_args = len(arg_names)
 
     deleted_args = 0
-    for i, arg in enumerate(arg_names):
+    for arg in arg_names:
         p = sig.parameters[arg]
 
-        # ignore keyword arguments
+        # Ignore keyword arguments.
         if p.kind in {p.KEYWORD_ONLY, p.VAR_KEYWORD}:
             continue
 
-        # stop when reacing non default args
+        # Stop when non-default arguments are reached.
         if not _is_not_empty(p.default):
             break
 

--- a/plum/function.py
+++ b/plum/function.py
@@ -98,7 +98,20 @@ def extract_signature(f):
     return signature, return_type
 
 
-def extract_default_args(signature, f):
+def append_default_args(signature, f):
+    """
+    Returns a list of signatures of function `f`, where those signatures are derived
+    from the input argument `signature`, excluding from 0 to all the positional
+    arguments with a default value.
+
+    Args:
+        f (function): Function to extract default arguments from.
+        signature (Signature): Signature of `f` from which to remove default arguments.
+
+    Returns:
+        list[:class:`.signature.Signature`]: list of signatures excluding from 0 to all
+        default arguments.
+    """
     # Extract specification.
     sig = inspect.signature(f)
 
@@ -341,7 +354,7 @@ class Function:
         # The return type may contain strings, which need to be converted Plum types.
         ret_type = ptype(return_type)
 
-        for sig in extract_default_args(signature, f):
+        for sig in append_default_args(signature, f):
             self._pending.append((sig, f, precedence, ret_type))
 
     def _resolve_pending_registrations(self):

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -106,14 +106,14 @@ def test_default():
     with pytest.raises(NotFoundLookupError):
         f(2, 4.0, option=2)
 
-    # wrong default type
+    # Wrong default type
     with pytest.raises(TypeError):
 
         @dispatch
         def f(x: int, y: float = y_default):
             return y
 
-    # ignore wrong type annotations on keyword arguments
+    # Ignore wrong type annotations on keyword arguments.
     def f(x: int, y: float = y_default, *, option: int = None):
         return y
 

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -69,13 +69,60 @@ def test_keywords():
     dispatch = Dispatcher()
 
     @dispatch
-    def f(x: int, option=None):
+    def f(x: int, *, option=None):
         return x
 
     assert f(2) == 2
     assert f(2, option=None) == 2
     with pytest.raises(NotFoundLookupError):
         f(2, None)
+
+
+def test_default():
+    dispatch = Dispatcher()
+
+    y_default = 3
+
+    @dispatch
+    def f(x: int, y: int = y_default, *, option=None):
+        return y
+
+    @dispatch
+    def f(x: float, y: int = y_default, *, option=None):
+        return y ** 2
+
+    assert f(2) == y_default
+    assert f(2, option=None) == y_default
+    assert f(2, 4) == 4
+    assert f(2, y=4) == 4
+    assert f(2, y=4, option=None) == 4
+
+    assert f(2.0) == y_default ** 2
+    assert f(2.0, y=4) == 4 ** 2
+
+    with pytest.raises(NotFoundLookupError):
+        f(2, 4.0)
+
+    with pytest.raises(NotFoundLookupError):
+        f(2, 4.0, option=2)
+
+    # wrong default type
+    with pytest.raises(TypeError):
+
+        @dispatch
+        def f(x: int, y: float = y_default):
+            return y
+
+    # ignore wrong type annotations on keyword arguments
+    def f(x: int, y: float = y_default, *, option: int = None):
+        return y
+
+    # multiple arguments
+    @dispatch
+    def g(x: int, y: int = y_default, z: float = 3.0):
+        return (y, z)
+
+    assert g(2) == (y_default, 3.0)
 
 
 def test_redefinition():


### PR DESCRIPTION
Closes #7

It's a simple solution though maybe not the most elegant.
When a signature is to be registered, it checks if some arguments have a default.
If so, it creates a new signature without those arguments (incrementally, so if you have 4 arguments of which the last 3 have defaults, you create 4 signatures).

To be elegantly correct, it should also check that the type of a default argument matches the type of the type annotation.
Though to do that correctly i need to check if the function is parametric or not
so i need to have already registered some signatures...

therefore i'll probably need to rewrite this.
But i'm just putting it here for anyone to see in the meantime.