### PR TITLE
Speedup parametric classes dispatch

### DIFF
--- a/plum/function.py
+++ b/plum/function.py
@@ -189,9 +189,9 @@ class Function:
         self._precedences = {}
 
         # Keep track of whether any of the signatures contains a parametric
-        # type with type determined at runtime by `plum.typeof` instead of `type`.
+        # type with type determined at runtime by `plum.type_of` instead of `type`.
         # This is a necessary performance optimisation.
-        self._runtime_typeof = False
+        self._runtime_type_of = False
 
         self._cache = {}
         self._owner = ptype(owner) if owner else None
@@ -283,7 +283,7 @@ class Function:
             self._resolved = []
             self._methods.clear()
             self._precedences.clear()
-            self._runtime_typeof = False
+            self._runtime_type_of = False
 
     def register(self, signature, f, precedence=0, return_type=object):
         """Register a method.
@@ -322,8 +322,8 @@ class Function:
             self._resolved.append((signature, f, precedence, return_type))
 
             # Check whether the signature contains a parametric type.
-            if any(t.runtime_typeof for t in signature.types):
-                self._runtime_typeof = True
+            if any(t.runtime_type_of for t in signature.types):
+                self._runtime_type_of = True
 
         if registered:
             self._pending = []
@@ -447,13 +447,13 @@ class Function:
 
     def __call__(self, *args, **kw_args):
         # First resolve pending registrations, because the value of
-        # `self._runtime_typeof` depends on it.
+        # `self._runtime_type_of` depends on it.
         if len(self._pending) != 0:
             self._resolve_pending_registrations()
 
         # Get types of arguments for signature. Only use `type_of` if
         # necessary, because it incurs a significant performance hit.
-        if not self._runtime_typeof:
+        if not self._runtime_type_of:
             sig_types = tuple([type(x) for x in args])
         else:
             sig_types = tuple([promised_type_of.resolve()(x) for x in args])

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -109,12 +109,12 @@ class CovariantMeta(ParametricTypeMeta):
 def parametric(Class=None, runtime_typeof=False):
     """A decorator for parametric classes.
 
-    Optional keyword arguments:
-        runtime_typeof: If this type cannot be inferred by python's built-in`type`,
-            but you need to specialize `plum.typeof` (for example to inspect runtime)
-            values, then this must be set to True.
-            Functions that have this class in one of its method's signature will be
-            noticeably slower on dispatch.
+    Args:
+        runtime_typeof (bool, optional): If this type cannot be inferred by Python's
+            built-in `type` and you need to specialise `plum.type_of`, for example to
+            inspect runtime values, then this must be set to `True`. Functions that have
+            this class in one of its method's signature will be noticeably slower on
+            dispatch.
     """
 
     # allow the kwargs to be passed in without using functools.partial explicitly

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -71,8 +71,8 @@ class ParametricTypeMeta(TypeMeta):
         return hasattr(cls, "_is_parametric")
 
     @property
-    def runtime_typeof(cls):
-        return cls._runtime_typeof
+    def runtime_type_of(cls):
+        return cls._runtime_type_of
 
 
 class CovariantMeta(ParametricTypeMeta):
@@ -106,11 +106,11 @@ class CovariantMeta(ParametricTypeMeta):
         return type.__subclasscheck__(self, subclass)
 
 
-def parametric(Class=None, runtime_typeof=False):
+def parametric(Class=None, runtime_type_of=False):
     """A decorator for parametric classes.
 
     Args:
-        runtime_typeof (bool, optional): If this type cannot be inferred by Python's
+        runtime_type_of (bool, optional): If this type cannot be inferred by Python's
             built-in `type` and you need to specialise `plum.type_of`, for example to
             inspect runtime values, then this must be set to `True`. Functions that have
             this class in one of its method's signature will be noticeably slower on
@@ -119,7 +119,7 @@ def parametric(Class=None, runtime_typeof=False):
 
     # allow the kwargs to be passed in without using functools.partial explicitly
     if Class is None:
-        return partial(parametric, runtime_typeof=runtime_typeof)
+        return partial(parametric, runtime_type_of=runtime_type_of)
 
     subclasses = {}
 
@@ -159,7 +159,7 @@ def parametric(Class=None, runtime_typeof=False):
     ParametricClass = ParametricTypeMeta(
         Class.__name__,
         (Class,),
-        {"__new__": __new__, "_runtime_typeof": runtime_typeof},
+        {"__new__": __new__, "_runtime_type_of": runtime_type_of},
     )
     ParametricClass.__module__ = Class.__module__
 
@@ -241,7 +241,7 @@ class List(ComparableType):
         return True
 
     @property
-    def runtime_typeof(self):
+    def runtime_type_of(self):
         return True
 
 
@@ -281,7 +281,7 @@ class Tuple(ComparableType):
         return True
 
     @property
-    def runtime_typeof(self):
+    def runtime_type_of(self):
         return True
 
 

--- a/plum/type.py
+++ b/plum/type.py
@@ -58,7 +58,7 @@ class AbstractType(metaclass=TypeMeta):
         type."""
 
     @property
-    def runtime_typeof(cls):
+    def runtime_type_of(cls):
         return False
 
 
@@ -226,9 +226,9 @@ class Type(ComparableType):
         return hasattr(self._type, "_is_parametric") and self._type._is_parametric
 
     @property
-    def runtime_typeof(self):
-        # Types don't specify `runtime_typeof` except for custom Plum types.
-        return hasattr(self._type, "runtime_typeof") and self._type.runtime_typeof
+    def runtime_type_of(self):
+        # Types don't specify `runtime_type_of` except for custom Plum types.
+        return hasattr(self._type, "runtime_type_of") and self._type.runtime_type_of
 
 
 class ResolvableType(ComparableType, Resolvable):

--- a/plum/type.py
+++ b/plum/type.py
@@ -227,7 +227,7 @@ class Type(ComparableType):
 
     @property
     def runtime_typeof(self):
-        # Types don-t specify runtime_typeof except for custom Plum Types
+        # Types don't specify `runtime_typeof` except for custom Plum types.
         return hasattr(self._type, "runtime_typeof") and self._type.runtime_typeof
 
 

--- a/plum/type.py
+++ b/plum/type.py
@@ -57,6 +57,10 @@ class AbstractType(metaclass=TypeMeta):
         """Boolean that indicates whether this is or contains a parametric
         type."""
 
+    @property
+    def runtime_typeof(cls):
+        return False
+
 
 class VarArgs(AbstractType):
     """Plum type that represents a variable number of the same Plum type.
@@ -220,6 +224,11 @@ class Type(ComparableType):
         # decorator from :mod:`.parametric`, which will have an attribute
         # `_is_parametric` with the value `True`.
         return hasattr(self._type, "_is_parametric") and self._type._is_parametric
+
+    @property
+    def runtime_typeof(self):
+        # Types don-t specify runtime_typeof except for custom Plum Types
+        return hasattr(self._type, "runtime_typeof") and self._type.runtime_typeof
 
 
 class ResolvableType(ComparableType, Resolvable):

--- a/tests/dispatcher/test_cache.py
+++ b/tests/dispatcher/test_cache.py
@@ -129,14 +129,14 @@ def test_cache_clearing():
     # Check that cache is used.
     assert len(f._methods) == 2
     assert len(f._precedences) == 2
-    assert f._parametric
+    assert f._runtime_typeof
 
     dispatch.clear_cache()
 
     # Check that cache is cleared.
     assert len(f._methods) == 0
     assert len(f._precedences) == 0
-    assert not f._parametric
+    assert not f._runtime_typeof
 
     f(1)
     clear_all_cache()
@@ -145,4 +145,4 @@ def test_cache_clearing():
     assert len(f._methods) == 0
     assert len(f._precedences) == 0
     assert len(subclasscheck_cache) == 0
-    assert not f._parametric
+    assert not f._runtime_typeof

--- a/tests/dispatcher/test_cache.py
+++ b/tests/dispatcher/test_cache.py
@@ -129,14 +129,14 @@ def test_cache_clearing():
     # Check that cache is used.
     assert len(f._methods) == 2
     assert len(f._precedences) == 2
-    assert f._runtime_typeof
+    assert f._runtime_type_of
 
     dispatch.clear_cache()
 
     # Check that cache is cleared.
     assert len(f._methods) == 0
     assert len(f._precedences) == 0
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
 
     f(1)
     clear_all_cache()
@@ -145,4 +145,4 @@ def test_cache_clearing():
     assert len(f._methods) == 0
     assert len(f._precedences) == 0
     assert len(subclasscheck_cache) == 0
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -353,9 +353,9 @@ def test_parametric_tracking():
     def f(x: int):
         pass
 
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
     f(1)
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
 
     @parametric
     class MockClass:
@@ -365,14 +365,14 @@ def test_parametric_tracking():
     def f(x: MockClass[1]):
         pass
 
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
     f(1)
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
 
     @dispatch
     def f(x: List[int]):
         pass
 
-    assert not f._runtime_typeof
+    assert not f._runtime_type_of
     f(1)
-    assert f._runtime_typeof
+    assert f._runtime_type_of

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -282,7 +282,7 @@ def test_type_of():
 def test_type_of_extension():
     dispatch = Dispatcher()
 
-    @parametric
+    @parametric(runtime_typeof=True)
     class NPArray(np.ndarray):
         pass
 

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -282,7 +282,7 @@ def test_type_of():
 def test_type_of_extension():
     dispatch = Dispatcher()
 
-    @parametric(runtime_typeof=True)
+    @parametric(runtime_type_of=True)
     class NPArray(np.ndarray):
         pass
 


### PR DESCRIPTION
This PR implements what we had talked about a few times.
Namely, `@parametric` classes that don't need a custom `type_of` implementation that checks the type at _runtime_ can still benefit from using python's builtin type, which is much faster.

I have added a new argument to the decorator, called `runtime_typeof` (defaults to `False`).
When this is `False` the same dispatch logic as non-parametric classes is used.
If it is `True` then dispatch will use `plum.type_of`.

Ideally this could be picked up automatically, but the implementation would be relatively more complicated.

--

By the way, while going around the codebase I now realised that a paramtric type is an instance of `ParametricMeta`, which is a metaclass, but it is not an `AbstractType`.
This maybe makes sense, because `AbstractType` is a concrete type used internally in plum, but it's a bit confusing...
Probably it is not important, though