### PR TITLE
[DIST] Build wheels for all platforms on GitHub actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.2.2
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,9 +15,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,12 +1,11 @@
 name: Build
 
 # Only trigger, when the build workflow succeeded
-#on:
-#  workflow_run:
-#    workflows: ["CI build"]
-#    types:
-#      - completed
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: ["CI build"]
+    types:
+      - completed
 
 jobs:
   build_wheels:
@@ -50,8 +49,8 @@ jobs:
       - name: Build and publish
         env:
           # Remove AA for production...
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}AA
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}AA
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
 
         run: |
           twine upload wheelhouse/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,5 +1,11 @@
 name: Build
 
+# Only trigger, when the build workflow succeeded
+#on:
+#  workflow_run:
+#    workflows: ["CI build"]
+#    types:
+#      - completed
 on: [push, pull_request]
 
 jobs:
@@ -19,8 +25,33 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
-        env:
-          CIBW_BUILD_VERBOSITY: 3
+
       - uses: actions/upload-artifact@v2
         with:
+          name: wheels
           path: ./wheelhouse/*.whl
+
+  # Upload wheels to PyPi
+  upload_wheels:
+    needs: build_wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built wheels
+        uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U twine 
+
+      - name: Build and publish
+        env:
+          # Remove AA for production...
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}AA
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}AA
+
+        run: |
+          twine upload wheelhouse/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # Make sure tags are fetched so we can get a version.
+      - run: |
+          git fetch --prune --unshallow --tags
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
         env:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
 
   # Upload wheels to PyPi
   upload_wheels:
-    needs: build_wheel
+    needs: build_wheels
     runs-on: ubuntu-latest
     steps:
       - name: Download built wheels

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.2.2
-
+        env:
+          CIBW_BUILD_VERBOSITY: 3
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Colleagues reported from time to time problems with install plum: sometimes you need to have python installed before doing `pip install plum-dispatch` otherwise pip fails with weird errors, if you have intel compilers compilation will fail because it does not accept some flags given to python...

distributing wheels might make it easier.

My plan is to first test this action (which is also used by sklearn and matplotlib, so it should be reliable) and check that the produced wheels work correctly.

Once this is done, I want to auto-upload the wheels when we publish to `pypi` 