### PR TITLE
make @parametric work with classes with arbitrary metaclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,6 +978,14 @@ class NTuple:
 __main__.NTuple[3, <class 'int'>]
 ```
 
+**Note:** The `@parametric` decorator injects a metaclass (`plum.parametric.CovariantMeta`) into the 
+decorated class. If the decorated class already has a metaclass, it creates a new metaclass which
+inherits from both the existing metaclass and `plum.parametric.CovariantMeta`.
+The only limitation to metaclasses is that it should not take over the `__getitem__` class method
+because that is used by plum to make sure that `class[parameter]` works. Note that `__getitem__`
+cannot be defined on the metaclass, but can freely be defined on the class itself.
+
+
 ### Hooking Into Type Inference
 
 With parametric classes, you can hook into Plum's type inference system to do cool

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -224,7 +224,8 @@ def parametric(Class=None, runtime_type_of=False, metaclass=CovariantMeta):
     # Support @parametric on classes with a different metaclass than Plum's
     # by creating inserting Plum's metaclass (usually CovariantMeta) as a superclass
     # of the object metaclass, and giving it a `__call__` method that constructs the
-    if type(Class) is not metaclass and type(Class) is not type:
+    original_metaclass = type(Class)
+    if original_metaclass not in (metaclass, abc.ABCMeta, type):
         original_metaclass = type(Class)
 
         def __call__(cls, *args, **kw_args):

--- a/plum/parametric.py
+++ b/plum/parametric.py
@@ -276,7 +276,7 @@ def parametric(Class=None, runtime_type_of=False, metaclass=CovariantMeta):
                 return Class.__new__(cls)
 
             cls.__new__ = resetted_new
-        Class.__init_subclass__(**kw_args)
+        super(Class, cls).__init_subclass__(**kw_args)
 
     # Create parametric class.
     ParametricClass = metaclass(

--- a/tests/test_parametric.py
+++ b/tests/test_parametric.py
@@ -159,6 +159,40 @@ def test_parametric_inheritance():
     assert type(E(1, 2, 3, 4, 5)) == E[int, int, int, int, int]
 
 
+def test_parametric_metaclass_inheritance():
+    import abc
+
+    # a Metaclass not inheriting from CovariantMeta
+    class MetaC(abc.ABCMeta):
+        def __call__(cls, *args, **kwargs):
+            obj = super().__call__(*args, **kwargs)
+            obj.value = 10
+            return obj
+
+    @parametric
+    class Test(metaclass=MetaC):
+        def __init__(self, arg):
+            self.arg = arg
+
+    a = Test(1)
+    assert type(a) == Test[int]
+    assert type(Test).__name__.endswith("CovariantMeta[MetaC]")
+    assert a.value == 10
+    assert a.arg == 1
+
+    @parametric
+    class Test2(metaclass=MetaC):
+        def __init__(self, arg):
+            self.arg = arg
+
+        @classmethod
+        def __infer_type_parameter__(cls, *args, **kw_args):
+            return (float,)
+
+    a = Test2(1)
+    assert type(a) == Test2[float]
+
+
 def test_constructor():
     @parametric
     class A:


### PR DESCRIPTION
I am experimenting with https://github.com/cgarciae/treeo and plum, and found out that since both inject meta classes they don't work together.

This PR makes plum work with classes which already have a meta class by injecting `CovariantMeta` as a superclass of the existing meta class, and by redefining `__call__` (essentially the constructor) to infer the parameters before calling into the existing class.

I'm surprised this was so easy to implement!