### PR TITLE
fix pyproject.toml build settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
-requires = [
-    "setuptools_scm[toml]>=6.0",
-]
+requires = ["setuptools>=50",
+            "wheel",
+            "toml",
+            "setuptools_scm[toml]>=6.0",
+            "setuptools_scm_git_archive"]
 
 [tool.setuptools_scm]
 write_to = "plum/_version.py"


### PR DESCRIPTION
@wesselb when you rewrote the pyproject.toml you removed too many things required by the build system. Those are often installed but I test from time to time plum in sandboxed environments where setuptools is not present unless you require it.